### PR TITLE
サインイン、サインアウト機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,10 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
+
 end


### PR DESCRIPTION
# WHAT 

ログインしていないユーザーをログインページに遷移させる。

# WHY 

ログインしていないユーザーが利用できる機能を制限するため。