### PR TITLE
メッセージ送信機能の実装及びビューの修正

### DIFF
--- a/app/assets/stylesheets/_left-content.scss
+++ b/app/assets/stylesheets/_left-content.scss
@@ -4,6 +4,7 @@
  min-height: 100%;
  width: 300px;
  float: left;
+ overflow:scroll;
    &__top{
     height: 100px;
     width: $left-contents-width;
@@ -26,12 +27,14 @@
     width: $left-contents-width;
     background-color: #2f3e51;
     padding: 20px 20px 20px 20px;
-      &--groupname p{
+      &--groupname #groupname{
         color: $fontcolor;
         font-size: 15px;
         margin-bottom: 5px;
+        text-decoration: none;
+        display: block;
       }
-      &--message p{
+      &--message {
         color: $fontcolor;
         font-size: 11px;
       }

--- a/app/assets/stylesheets/_main-content.scss
+++ b/app/assets/stylesheets/_main-content.scss
@@ -13,11 +13,7 @@
             margin-top: 35px;
             margin-bottom: 10px;
             font-size: 20px;
-            color: #333333;
-            p{
-              font-size: 20px;
-              color: #333333;
-            }
+            color: $groupname;
           }
           &__members{
               p{

--- a/app/assets/stylesheets/_main-content.scss
+++ b/app/assets/stylesheets/_main-content.scss
@@ -73,18 +73,10 @@
         &__message{
           float: left;
           clear: both;
-          // margin-bottom: 40px;
             p{
               font-size: 14px;
               color: $chat-fontcolor;
             }
-        // &__image{
-        //   height: 100%;
-        //   float: left;
-        //   image{
-        //     float: left;
-        //   }
-        // }
         }
       }
   }

--- a/app/assets/stylesheets/_main-content.scss
+++ b/app/assets/stylesheets/_main-content.scss
@@ -50,7 +50,6 @@
     padding: 0 40px;
     overflow:scroll;
       &__chatinfo{
-        height: 60px;
         width: 100%;
         float: left;
         margin-top: 46px;
@@ -74,11 +73,18 @@
         &__message{
           float: left;
           clear: both;
-          margin-bottom: 40px;
+          // margin-bottom: 40px;
             p{
               font-size: 14px;
               color: $chat-fontcolor;
             }
+        // &__image{
+        //   height: 100%;
+        //   float: left;
+        //   image{
+        //     float: left;
+        //   }
+        // }
         }
       }
   }

--- a/app/assets/stylesheets/_main-content.scss
+++ b/app/assets/stylesheets/_main-content.scss
@@ -11,7 +11,9 @@
         float: left;
           &__groupname{
             margin-top: 35px;
-            margin-bottom: 15px;
+            margin-bottom: 10px;
+            font-size: 20px;
+            color: #333333;
             p{
               font-size: 20px;
               color: #333333;
@@ -21,6 +23,7 @@
               p{
                 font-size: 12px;
                 color: $info-fontcolor;
+                float: left;
               }
           }
       }
@@ -28,13 +31,14 @@
         height: 40px;
         width: 70px;
         float: right;
-        background-color: #fff;
         margin-top: 28px;
-          p{
+          #edit{
             color: $button-color;
             text-align: center;
             line-height: 40px;
-            border: 1px solid $button-color;
+            border: 2px solid $button-color;
+            display: block;
+            text-decoration: none;
           }
       }
   }
@@ -44,6 +48,7 @@
     background-color: #F5F5F5;
     float: left;
     padding: 0 40px;
+    overflow:scroll;
       &__chatinfo{
         height: 60px;
         width: 100%;
@@ -85,7 +90,7 @@
     padding: 0 40px;
     position: relative;
       .fa{
-        line-height: 46px;
+        line-height: 50px;
         float: left;
         margin-right: 10px;
         cursor: pointer;

--- a/app/assets/stylesheets/_main-content.scss
+++ b/app/assets/stylesheets/_main-content.scss
@@ -13,7 +13,7 @@
             margin-top: 35px;
             margin-bottom: 10px;
             font-size: 20px;
-            color: $groupname;
+            color: $groupname-grey;
           }
           &__members{
               p{

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -16,3 +16,4 @@ $info-fontcolor: #999999;
 $button-color: #38aef0;
 $button-font-color: #fff;
 $main-contents-width: calc(100vw - 300px - 80px);
+$groupname: #333333;

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -16,4 +16,4 @@ $info-fontcolor: #999999;
 $button-color: #38aef0;
 $button-font-color: #fff;
 $main-contents-width: calc(100vw - 300px - 80px);
-$groupname: #333333;
+$groupname-grey: #333333;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     if @group.save
-      redirect_to root_path, notice: "グループを作成しました"
+      redirect_to group_messages_path(@group.id), notice: "グループを作成しました"
     else
       render :new
     end
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: "チャットグループが更新されました"
+      redirect_to group_messages_path(@group.id), notice: "チャットグループが更新されました"
     else
       render :edit
     end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,2 +1,11 @@
 module MessagesHelper
+ def chatinfo(group)
+  if group.messages.blank?
+    "まだメッセージはありません。"
+  elsif group.messages.last.image.present?
+    "画像が投稿されています。"
+  else
+    group.messages.last.body
+  end
+ end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,5 +2,9 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :group
   mount_uploader :image, ImageUploader
-  validates :body, presence: true
+  validates :body, presence: true, unless: :have_image?
+
+  def have_image?
+    image.present?
+  end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   storage :file
@@ -45,5 +45,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+  process resize_to_limit: [300, 200]
 
 end

--- a/app/views/shared/_left-content.html.haml
+++ b/app/views/shared/_left-content.html.haml
@@ -13,7 +13,7 @@
       .left-content__main--message
         - if group.messages.empty?
           %p まだメッセージはありません。
-        - elsif group.messages.present?
-          = group.messages.last.body
-        - else
+        - elsif group.messages.last.image.present?
           %p 画像が投稿されています。
+        - else
+          = group.messages.last.body

--- a/app/views/shared/_left-content.html.haml
+++ b/app/views/shared/_left-content.html.haml
@@ -9,6 +9,11 @@
   - current_user.groups.each do |group|
     .left-content__main
       .left-content__main--groupname
-        %p= group.groupname
+        = link_to group.groupname, group_messages_path(group.id), id: "groupname"
       .left-content__main--message
-        %p まだメッセージはありません。
+        - if group.messages.empty?
+          %p まだメッセージはありません。
+        - elsif group.messages.present?
+          = group.messages.last.body
+        - else
+          %p 画像が投稿されています。

--- a/app/views/shared/_left-content.html.haml
+++ b/app/views/shared/_left-content.html.haml
@@ -9,7 +9,7 @@
   - current_user.groups.each do |group|
     .left-content__main
       .left-content__main--groupname
-        = link_to group.groupname, group_messages_path(group.id), id: "groupname"
+        = link_to group.groupname, group_messages_path(group), id: "groupname"
       .left-content__main--message
         - if group.messages.empty?
           %p まだメッセージはありません。

--- a/app/views/shared/_left-content.html.haml
+++ b/app/views/shared/_left-content.html.haml
@@ -11,7 +11,7 @@
       .left-content__main--groupname
         = link_to group.groupname, group_messages_path(group), id: "groupname"
       .left-content__main--message
-        - if group.messages.empty?
+        - if group.messages.blank?
           %p まだメッセージはありません。
         - elsif group.messages.last.image.present?
           %p 画像が投稿されています。

--- a/app/views/shared/_left-content.html.haml
+++ b/app/views/shared/_left-content.html.haml
@@ -11,9 +11,4 @@
       .left-content__main--groupname
         = link_to group.groupname, group_messages_path(group), id: "groupname"
       .left-content__main--message
-        - if group.messages.blank?
-          %p まだメッセージはありません。
-        - elsif group.messages.last.image.present?
-          %p 画像が投稿されています。
-        - else
-          = group.messages.last.body
+        = chatinfo(group)

--- a/app/views/shared/_main-content.html.haml
+++ b/app/views/shared/_main-content.html.haml
@@ -14,7 +14,7 @@
     - @group.messages.each do |message|
       .main-content__center__chatinfo
         .main-content__center__chatinfo__username
-          %p= current_user.name
+          %p= message.user.name
         .main-content__center__chatinfo__date
           %p= message.updated_at.strftime("%Y/%m/%d %H:%M:%S")
         .main-content__center__chatinfo__message

--- a/app/views/shared/_main-content.html.haml
+++ b/app/views/shared/_main-content.html.haml
@@ -3,19 +3,23 @@
   .main-content__top
     .main-content__top__groupinfo
       .main-content__top__groupinfo__groupname
-        %p sampleグループ
+        = @group.groupname
       .main-content__top__groupinfo__members
-        %p Members: Tomoya_Ishida
+        %p Members:&nbsp;
+        - @group.users.each do |user|
+          %p #{user.name}&nbsp;
     .main-content__top__edit-button
-      %p Edit
+      = link_to "Edit", edit_group_path(@group.id), id: "edit"
   .main-content__center
-    .main-content__center__chatinfo
-      .main-content__center__chatinfo__username
-        %p Tomoya Ishida
-      .main-content__center__chatinfo__date
-        %p 2017/06/03 16:01:30
-      .main-content__center__chatinfo__message
-        %p Hello World!!
+    - @group.messages.each do |message|
+      .main-content__center__chatinfo
+        .main-content__center__chatinfo__username
+          %p= current_user.name
+        .main-content__center__chatinfo__date
+          %p= message.updated_at.strftime("%Y/%m/%d %H:%M:%S")
+        .main-content__center__chatinfo__message
+          %p= message.body
+          = image_tag message.image
   .main-content__bottom
     = form_for ([@group,@message]) do |f| 
       = f.text_field :body, placeholder: "type a message", class: "main-content__bottom__messagebox"

--- a/app/views/shared/_main-content.html.haml
+++ b/app/views/shared/_main-content.html.haml
@@ -6,20 +6,11 @@
         = @group.groupname
       .main-content__top__groupinfo__members
         %p Members:&nbsp;
-        - @group.users.each do |user|
-          %p #{user.name}&nbsp;
+        = render partial: "shared/member"
     .main-content__top__edit-button
       = link_to "Edit", edit_group_path(@group.id), id: "edit"
   .main-content__center
-    - @group.messages.each do |message|
-      .main-content__center__chatinfo
-        .main-content__center__chatinfo__username
-          %p= message.user.name
-        .main-content__center__chatinfo__date
-          %p= message.updated_at.strftime("%Y/%m/%d %H:%M:%S")
-        .main-content__center__chatinfo__message
-          %p= message.body
-          = image_tag message.image
+    = render partial: "shared/message"
   .main-content__bottom
     = form_for ([@group,@message]) do |f| 
       = f.text_field :body, placeholder: "type a message", class: "main-content__bottom__messagebox"

--- a/app/views/shared/_member.html.haml
+++ b/app/views/shared/_member.html.haml
@@ -1,0 +1,2 @@
+- @group.users.each do |user|
+  %p #{user.name}&nbsp;

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -1,0 +1,9 @@
+- @group.messages.each do |message|
+  .main-content__center__chatinfo
+    .main-content__center__chatinfo__username
+      %p= message.user.name
+    .main-content__center__chatinfo__date
+      %p= message.updated_at.strftime("%Y/%m/%d %H:%M:%S")
+    .main-content__center__chatinfo__message
+      %p= message.body
+      = image_tag message.image


### PR DESCRIPTION
# WHAT 

メッセージの内容に合わせてサイドバーの表示を変更、メッセージ表示画面の修正、画像のみの送信を許可するバリデーションの設定。

# WHY 

Chatspace実装に必要なため。

# 参考スクリーンショット

<img width="1440" alt="2017-06-12 14 39 12" src="https://user-images.githubusercontent.com/29084519/27020663-2304b2ec-4f7e-11e7-9118-443b187250c2.png">


